### PR TITLE
AAI-249 - Enable automated grant access to TSI CKAN org

### DIFF
--- a/ckanext/oidc_pkce_bpa/plugin.py
+++ b/ckanext/oidc_pkce_bpa/plugin.py
@@ -95,6 +95,8 @@ class OidcPkceBpaPlugin(SingletonPlugin):
             user.fullname = updated_fullname
 
     def get_blueprint(self):
+        bp = Blueprint("oidc_pkce_bpa", __name__)
+
         @bp.route("/user/register")
         def force_oidc_register():
             # hard-redirect to AAI portal user registration page

--- a/ckanext/oidc_pkce_bpa/plugin.py
+++ b/ckanext/oidc_pkce_bpa/plugin.py
@@ -39,6 +39,8 @@ class OidcPkceBpaPlugin(SingletonPlugin):
             raise tk.ValidationError("No access token available during get_oidc_user()!")
 
         # Apply roles → membership once, as site user (authorised context).
+        # The mapping of Auth0 roles to CKAN organisations is configured via
+        # `ckanext.oidc_pkce_bpa.role_org_mapping`.
         token_service = utils.get_token_service()
         try:
             roles = token_service.get_user_roles(access_token)

--- a/ckanext/oidc_pkce_bpa/plugin.py
+++ b/ckanext/oidc_pkce_bpa/plugin.py
@@ -21,42 +21,45 @@ class OidcPkceBpaPlugin(SingletonPlugin):
 
     def get_oidc_user(self, userinfo: dict) -> model.User:
         """
-        Upstream calls this with only `userinfo`. We fetch app_metadata via
-        the Auth0 Management API using the user's `sub` and then normalise +
-        stash it for UI (and optionally sync into ytp-request).
+        Called post-OIDC login. We resolve/create the CKAN user, then
+        (as the site user) grant organization access based on roles in
+        the Auth0 access token.
         """
         sub = userinfo.get("sub")
         if not sub:
             raise tk.NotAuthorized("'userinfo' missing 'sub' claim during get_oidc_user().")
 
-        # Resolve or create the CKAN user
         username = utils.extract_username(userinfo)
-        user = model.User.get(username)
-        if not user:
-            user = self._create_new_user(userinfo, username)
-
-        # Keep basic identity fields aligned
+        user = model.User.get(username) or self._create_new_user(userinfo, username)
         self._ensure_auth0_id(user, sub)
         self._update_fullname_if_needed(user, userinfo)
+
+        access_token = userinfo.get("access_token")
+        if not access_token:
+            raise tk.ValidationError("No access token available during get_oidc_user()!")
+
+        # Apply roles → membership once, as site user (authorised context).
+        token_service = utils.get_token_service()
+        try:
+            roles = token_service.get_user_roles(access_token)
+        except Exception as e:
+            log.warning("Failed to read Auth0 roles for '%s': %s", user.name, e)
+        else:
+            log.debug("Auth0 roles for '%s': %s", user.name, roles)
+            try:
+                site_ctx = utils.get_site_context()
+                membership_service = utils.get_membership_service()
+                membership_service.apply_role_based_memberships(
+                    user_name=user.name,
+                    roles=roles,
+                    context=site_ctx,
+                )
+            except Exception as e:
+                log.warning("Role membership apply at login failed for '%s': %s", user.name, e)
 
         model.Session.add(user)
         model.Session.commit()
         return user
-
-    def apply_role_memberships(self, *, user: model.User, access_token: str):
-        """
-        Decode roles from the access token and apply role-triggered membership actions.
-        Currently: if role == 'biocommons/group/tsi', create a pending request for
-        the 'aai-threatened-species-initiative-embargo' organization (idempotent).
-        """
-        try:
-            roles = utils.get_user_roles(access_token)
-        except Exception as e:
-            log.warning("Could not read roles from access token for user '%s': %s", user.name, e)
-            return
-
-        context = {"model": model, "user": user.name}
-        utils.apply_role_based_memberships(user_name=user.name, roles=roles, context=context)
 
 
     def _create_new_user(self, userinfo: dict, username: str) -> model.User:
@@ -92,16 +95,14 @@ class OidcPkceBpaPlugin(SingletonPlugin):
             user.fullname = updated_fullname
 
     def get_blueprint(self):
-        bp = Blueprint("oidc_pkce_bpa_routes", __name__)
-
         @bp.route("/user/register")
         def force_oidc_register():
             # hard-redirect to AAI portal user registration page
             return redirect(utils.get_redirect_registeration_url())
-
+    
         @bp.route("/user/login")
         def force_oidc_login():
             # redirect into OIDC login route inside CKAN
             return tk.redirect_to("oidc_pkce.login")
-
+    
         return bp

--- a/ckanext/oidc_pkce_bpa/plugin.py
+++ b/ckanext/oidc_pkce_bpa/plugin.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 class OidcPkceBpaPlugin(SingletonPlugin):
     implements(IOidcPkce, inherit=True)
-    # implements(IBlueprint)
+    implements(IBlueprint)
 
     def get_oidc_user(self, userinfo: dict) -> model.User:
         """

--- a/ckanext/oidc_pkce_bpa/tests/test_plugin.py
+++ b/ckanext/oidc_pkce_bpa/tests/test_plugin.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -30,8 +31,7 @@ def mock_config(monkeypatch):
         "ckanext.oidc_pkce_bpa.api_audience": "test-audience",
         "ckanext.oidc_pkce_bpa.auth0_domain": "auth0.example.com",
         "ckanext.oidc_pkce_bpa.roles_claim": "https://example.com/roles",
-        "ckanext.oidc_pkce_bpa.tsi_role": "tsi-member",
-        "ckanext.oidc_pkce_bpa.tsi_org_id": "org-123",
+        "ckanext.oidc_pkce_bpa.role_org_mapping": json.dumps({"tsi-member": ["org-123"]}),
         "ckanext.oidc_pkce_bpa.username_claim": "https://biocommons.org.au/username",
         "ckanext.oidc_pkce_bpa.register_redirect_url": "https://example.com/register",
     }

--- a/ckanext/oidc_pkce_bpa/tests/test_plugin.py
+++ b/ckanext/oidc_pkce_bpa/tests/test_plugin.py
@@ -1,41 +1,78 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 from ckan import model
 import ckan.plugins.toolkit as tk
 
-from ckanext.oidc_pkce_bpa.plugin import OidcPkceBpaPlugin
 from ckanext.oidc_pkce_bpa import utils
+from ckanext.oidc_pkce_bpa.plugin import OidcPkceBpaPlugin
 
 
 @pytest.fixture
 def plugin():
-    """Fixture to initialize the plugin."""
+    """Initialise the plugin once per test."""
     return OidcPkceBpaPlugin()
 
 
 @pytest.fixture
 def clean_session():
-    """Fixture to clean up the database session after each test."""
+    """Ensure SQLAlchemy session state is cleaned between tests."""
     yield
     model.Session.remove()
 
 
 @pytest.fixture
 def mock_config(monkeypatch):
-    """Fixture to set constants used by utils.extract_username."""
-    fake_cfg = {"ckanext.oidc_pkce_bpa.username_claim": "https://biocommons.org.au/username"}
-    # Patch both the alias inside utils and the toolkit config (belt & braces)
+    """Provide the Auth0-related configuration expected by utils."""
+    fake_cfg = {
+        "ckanext.oidc_pkce_bpa.api_audience": "test-audience",
+        "ckanext.oidc_pkce_bpa.auth0_domain": "auth0.example.com",
+        "ckanext.oidc_pkce_bpa.roles_claim": "https://example.com/roles",
+        "ckanext.oidc_pkce_bpa.tsi_role": "tsi-member",
+        "ckanext.oidc_pkce_bpa.tsi_org_id": "org-123",
+        "ckanext.oidc_pkce_bpa.username_claim": "https://biocommons.org.au/username",
+        "ckanext.oidc_pkce_bpa.register_redirect_url": "https://example.com/register",
+    }
+
+    utils.get_auth0_settings.cache_clear()
     monkeypatch.setattr(utils, "ckan_config", fake_cfg, raising=False)
     monkeypatch.setattr(tk, "config", fake_cfg, raising=False)
-    yield
+    yield fake_cfg
+    utils.get_auth0_settings.cache_clear()
 
 
-def test_create_new_user(plugin, clean_session, mock_config):
-    """Test creating a new user with OIDC user info."""
+@pytest.fixture
+def mock_services(monkeypatch, mock_config):
+    """Stub out token and membership services to avoid external effects."""
+    utils.get_token_service.cache_clear()
+    utils.get_membership_service.cache_clear()
+
+    token_service = MagicMock()
+    token_service.get_user_roles.return_value = ["tsi-member"]
+
+    membership_service = MagicMock()
+    site_context = {"ignore_auth": True, "user": "site_user"}
+
+    monkeypatch.setattr(utils, "get_token_service", lambda: token_service)
+    monkeypatch.setattr(utils, "get_membership_service", lambda: membership_service)
+    monkeypatch.setattr(utils, "get_site_context", lambda: site_context)
+
+    return SimpleNamespace(
+        token_service=token_service,
+        membership_service=membership_service,
+        site_context=site_context,
+    )
+
+
+def test_create_new_user(plugin, clean_session, mock_services):
+    """A new CKAN user is created and synced with membership roles."""
     userinfo = {
         "sub": "auth0|123",
         "email": "newuser@example.com",
         "name": "New User",
         "https://biocommons.org.au/username": "newuser",
+        "access_token": "token-123",
     }
 
     user = plugin.get_oidc_user(userinfo)
@@ -44,11 +81,22 @@ def test_create_new_user(plugin, clean_session, mock_config):
     assert user.email == "newuser@example.com"
     assert user.fullname == "New User"
     assert user.plugin_extras["oidc_pkce"]["auth0_id"] == "auth0|123"
+    mock_services.token_service.get_user_roles.assert_called_once_with("token-123")
+    mock_services.membership_service.apply_role_based_memberships.assert_called_once_with(
+        user_name="newuser",
+        roles=["tsi-member"],
+        context=mock_services.site_context,
+    )
 
 
-def test_existing_user_backfill_auth0(plugin, clean_session, mock_config):
-    """Test updating an existing user with missing Auth0 ID."""
-    user = model.User(name="existinguser", email="existing@example.com", fullname="Existing User", password="")
+def test_existing_user_backfill_auth0(plugin, clean_session, mock_services):
+    """Existing users receive a backfilled Auth0 ID and membership sync."""
+    user = model.User(
+        name="existinguser",
+        email="existing@example.com",
+        fullname="Existing User",
+        password="",
+    )
     model.Session.add(user)
     model.Session.commit()
 
@@ -60,16 +108,28 @@ def test_existing_user_backfill_auth0(plugin, clean_session, mock_config):
         "email": "existing@example.com",
         "name": "Existing User",
         "https://biocommons.org.au/username": "existinguser",
+        "access_token": "token-456",
     }
 
     updated_user = plugin.get_oidc_user(userinfo)
 
     assert updated_user.plugin_extras["oidc_pkce"]["auth0_id"] == "auth0|456"
+    mock_services.token_service.get_user_roles.assert_called_once_with("token-456")
+    mock_services.membership_service.apply_role_based_memberships.assert_called_once_with(
+        user_name="existinguser",
+        roles=["tsi-member"],
+        context=mock_services.site_context,
+    )
 
 
-def test_existing_user_update_fullname(plugin, clean_session, mock_config):
-    """Test updating the fullname of an existing user."""
-    user = model.User(name="fullnameuser", email="full@example.com", fullname="Old Name", password="")
+def test_existing_user_update_fullname(plugin, clean_session, mock_services):
+    """Full name changes from Auth0 propagate to existing CKAN users."""
+    user = model.User(
+        name="fullnameuser",
+        email="full@example.com",
+        fullname="Old Name",
+        password="",
+    )
     user.plugin_extras = {"oidc_pkce": {"auth0_id": "auth0|789"}}
     model.Session.add(user)
     model.Session.commit()
@@ -79,30 +139,55 @@ def test_existing_user_update_fullname(plugin, clean_session, mock_config):
         "email": "full@example.com",
         "name": "New Name",
         "https://biocommons.org.au/username": "fullnameuser",
+        "access_token": "token-789",
     }
 
     updated_user = plugin.get_oidc_user(userinfo)
 
     assert updated_user.fullname == "New Name"
+    mock_services.token_service.get_user_roles.assert_called_once_with("token-789")
+    mock_services.membership_service.apply_role_based_memberships.assert_called_once_with(
+        user_name="fullnameuser",
+        roles=["tsi-member"],
+        context=mock_services.site_context,
+    )
 
 
 def test_missing_sub_raises(plugin):
-    """Test that missing 'sub' in userinfo raises NotAuthorized."""
+    """Missing `sub` is rejected before any downstream work is attempted."""
     userinfo = {
         "email": "missing@example.com",
-        "https://biocommons.org.au/username": "someuser"
+        "https://biocommons.org.au/username": "someuser",
     }
 
     with pytest.raises(tk.NotAuthorized, match="sub"):
         plugin.get_oidc_user(userinfo)
 
 
-def test_missing_username_raises(plugin):
-    """Test that missing username in userinfo raises NotAuthorized."""
+def test_missing_username_raises(plugin, mock_services):
+    """Missing username claim bubbles up as a NotAuthorized error."""
     userinfo = {
         "sub": "auth0|999",
         "email": "missing@example.com",
+        "access_token": "token-999",
     }
 
     with pytest.raises(tk.NotAuthorized, match="Missing 'username' in Auth0 ID token"):
         plugin.get_oidc_user(userinfo)
+
+    mock_services.token_service.get_user_roles.assert_not_called()
+
+
+def test_missing_access_token_raises(plugin, mock_services):
+    """Access tokens are mandatory so that role membership stays in sync."""
+    userinfo = {
+        "sub": "auth0|555",
+        "email": "person@example.com",
+        "https://biocommons.org.au/username": "person",
+    }
+
+    with pytest.raises(tk.ValidationError, match="No access token"):
+        plugin.get_oidc_user(userinfo)
+
+    mock_services.token_service.get_user_roles.assert_not_called()
+    mock_services.membership_service.apply_role_based_memberships.assert_not_called()

--- a/ckanext/oidc_pkce_bpa/tests/test_plugin.py
+++ b/ckanext/oidc_pkce_bpa/tests/test_plugin.py
@@ -191,3 +191,17 @@ def test_missing_access_token_raises(plugin, mock_services):
 
     mock_services.token_service.get_user_roles.assert_not_called()
     mock_services.membership_service.apply_role_based_memberships.assert_not_called()
+
+
+def test_blueprint_routes(plugin, mock_config, monkeypatch):
+    """Blueprint routes perform the expected redirects."""
+    blueprint = plugin.get_blueprint()
+
+    register_view = blueprint.view_functions["oidc_pkce_bpa.force_oidc_register"]
+    response = register_view()
+    assert response.status_code == 302
+    assert response.location == "https://example.com/register"
+
+    monkeypatch.setattr(tk, "redirect_to", lambda endpoint: f"redirect:{endpoint}")
+    login_view = blueprint.view_functions["oidc_pkce_bpa.force_oidc_login"]
+    assert login_view() == "redirect:oidc_pkce.login"

--- a/ckanext/oidc_pkce_bpa/tests/test_utils.py
+++ b/ckanext/oidc_pkce_bpa/tests/test_utils.py
@@ -1,19 +1,37 @@
 import pytest
-from unittest.mock import patch
-from ckanext.oidc_pkce_bpa import utils
 import ckan.plugins.toolkit as tk
 
+from ckanext.oidc_pkce_bpa import utils
 
-def test_extract_username_from_claim(monkeypatch):
-    # Patch ckan_config.get to return our fake claim key
-    monkeypatch.setattr(utils, "ckan_config", {"ckanext.oidc_pkce_bpa.username_claim": "claim_key"})
-    userinfo = {"claim_key": "theuser"}
+
+@pytest.fixture
+def auth0_config(monkeypatch):
+    """Seed the configuration needed for Auth0 settings resolution."""
+    config = {
+        "ckanext.oidc_pkce_bpa.api_audience": "test-audience",
+        "ckanext.oidc_pkce_bpa.auth0_domain": "auth0.example.com",
+        "ckanext.oidc_pkce_bpa.roles_claim": "https://example.com/roles",
+        "ckanext.oidc_pkce_bpa.tsi_role": "tsi-member",
+        "ckanext.oidc_pkce_bpa.tsi_org_id": "org-123",
+        "ckanext.oidc_pkce_bpa.username_claim": "claim_key",
+        "ckanext.oidc_pkce_bpa.register_redirect_url": "http://example.com/register",
+    }
+
+    utils.get_auth0_settings.cache_clear()
+    monkeypatch.setattr(utils, "ckan_config", config, raising=False)
+    monkeypatch.setattr(tk, "config", config, raising=False)
+    yield config
+    utils.get_auth0_settings.cache_clear()
+
+
+def test_extract_username_from_claim(auth0_config):
+    claim_key = auth0_config["ckanext.oidc_pkce_bpa.username_claim"]
+    userinfo = {claim_key: "theuser"}
     assert utils.extract_username(userinfo) == "theuser"
 
 
-def test_extract_username_fallback_and_missing(monkeypatch):
-    monkeypatch.setattr(utils, "ckan_config", {"ckanext.oidc_pkce_bpa.username_claim": "claim_key"})
-    # Falls back to nickname
+def test_extract_username_fallback_and_missing(auth0_config):
+    # Falls back to nickname when the configured claim is absent.
     assert utils.extract_username({"nickname": "nick"}) == "nick"
 
     # Missing both claim and nickname -> raises
@@ -21,8 +39,7 @@ def test_extract_username_fallback_and_missing(monkeypatch):
         utils.extract_username({})
 
 
-def test_get_redirect_registeration_url_present(monkeypatch):
-    monkeypatch.setattr(utils, "ckan_config", {"ckanext.oidc_pkce_bpa.register_redirect_url": "http://example.com/register"})
+def test_get_redirect_registeration_url_present(auth0_config):
     assert utils.get_redirect_registeration_url() == "http://example.com/register"
 
 

--- a/ckanext/oidc_pkce_bpa/utils.py
+++ b/ckanext/oidc_pkce_bpa/utils.py
@@ -1,9 +1,38 @@
+import json
+import jwt
 import logging
+import requests
+from typing import Any, Dict, List
 
 import ckan.plugins.toolkit as tk
 from ckan.plugins.toolkit import config as ckan_config, NotAuthorized
 
 log = logging.getLogger(__name__)
+
+# Required Auth0/OIDC settings
+API_AUDIENCE = ckan_config.get("ckanext.oidc_pkce_bpa.api_audience")
+AUTH0_DOMAIN = ckan_config.get("ckanext.oidc_pkce_bpa.auth0_domain")
+JWKS_URL = f"https://{AUTH0_DOMAIN}/.well-known/jwks.json"
+
+# Defaults to your Action’s namespaced claim; allow override via ckan.ini
+ROLES_CLAIM = ckan_config.get(
+    "ckanext.oidc_pkce_bpa.roles_claim",
+    "https://biocommons.org.au/roles",
+)
+
+TSI_ROLE = "biocommons/group/tsi"
+TSI_ORG_ID = "aai-threatened-species-initiative-embargo"
+
+# PyJWT compatibility
+try:
+    from jwt.algorithms import RSAAlgorithm  # PyJWT < 2.10
+except ImportError:
+    RSAAlgorithm = None
+
+try:
+    from jwt import PyJWKClient  # PyJWT >= 2.0
+except ImportError:
+    PyJWKClient = None
 
 
 def extract_username(userinfo: dict) -> str:
@@ -13,8 +42,155 @@ def extract_username(userinfo: dict) -> str:
         raise tk.NotAuthorized("Missing 'username' in Auth0 ID token")
     return username
 
+
 def get_redirect_registeration_url() -> str:
     register_redirect_url = ckan_config.get("ckanext.oidc_pkce_bpa.register_redirect_url")
     if not register_redirect_url:
         raise tk.NotAuthorized("redirect_registation_url not set in ckan.ini!")
     return register_redirect_url
+
+
+
+def _get_jwks() -> Dict[str, Any]:
+    """Fetch Auth0 JWKS for RS256 verification."""
+    resp = requests.get(JWKS_URL, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _get_signing_key(token: str):
+    """
+    Resolve signing key from JWKS.
+    Supports both old (RSAAlgorithm) and new (PyJWKClient) PyJWT versions.
+    """
+    if RSAAlgorithm is not None:
+        unverified = jwt.get_unverified_header(token)
+        jwks = _get_jwks()
+        for key in jwks.get("keys", []):
+            if key.get("kid") == unverified.get("kid"):
+                return RSAAlgorithm.from_jwk(json.dumps(key))
+        raise Exception("Unable to find signing key for the token")
+
+    if PyJWKClient is not None:
+        jwk_client = PyJWKClient(JWKS_URL)
+        return jwk_client.get_signing_key_from_jwt(token).key
+
+    raise ImportError("Neither RSAAlgorithm nor PyJWKClient available; unsupported PyJWT version")
+
+
+def _decode_access_token(token: Any) -> Dict[str, Any]:
+    """
+    Decode & verify an Auth0 access token (RS256 + JWKS).
+    Returns {} on failure; callers raise if they need to.
+    """
+    if isinstance(token, dict):
+        log.info("Token is already a dict — skipping JWT decode")
+        return token
+    if isinstance(token, bytes):
+        token = token.decode("utf-8")
+
+    # Early sanity check (no verification) for clearer logs
+    try:
+        jwt.decode(token, options={"verify_signature": False, "verify_aud": False})
+    except Exception as e:
+        log.error(f"Failed to decode JWT without verification: {e}")
+        return {}
+
+    try:
+        key = _get_signing_key(token)
+        return jwt.decode(
+            token,
+            key=key,
+            algorithms=["RS256"],
+            audience=API_AUDIENCE,
+            issuer=f"https://{AUTH0_DOMAIN}/",
+        )
+    except Exception as e:
+        log.error(f"JWT verification failed: {e}")
+        return {}
+
+
+def _get_roles_from_claims(claims: Dict[str, Any]) -> List[str]:
+    """
+    Extract roles from the configured namespaced claim (array preferred, but
+    comma/space-delimited strings tolerated).
+    """
+    roles: List[str] = []
+    val = claims.get(ROLES_CLAIM)
+
+    if isinstance(val, list):
+        roles.extend(str(v) for v in val if v)
+    elif isinstance(val, str):
+        roles.extend(s for s in (x.strip() for x in val.replace(",", " ").split()) if s)
+
+    # Deduplicate and sort for stable output
+    return sorted({r for r in roles if isinstance(r, str) and r})
+
+
+def get_user_roles(access_token: Any) -> List[str]:
+    """
+    Public helper: verify the access token and return roles from
+    the namespaced claim (default: https://biocommons.org.au/roles).
+    """
+    if not access_token:
+        raise tk.NotAuthorized("Access token is required but missing")
+
+    claims = _decode_access_token(access_token)
+    if not claims:
+        raise tk.ValidationError("Unable to decode or verify access token")
+
+    return _get_roles_from_claims(claims)
+
+
+def _create_pending_membership_if_absent(*, org_id: str, user_name: str, context: Dict[str, Any]):
+    """
+    Idempotently create a pending membership request for user/org.
+    Mirrors the snippet you provided.
+    """
+    try:
+        existing = tk.get_action("member_requests_list")(context, {
+            "object_id": org_id,
+            "object_type": "organization",
+            "type": "membership",
+            "user": user_name,
+            "status": "pending",
+        })
+        if existing:
+            log.info("Pending request already exists for user '%s' in org '%s', skipping.", user_name, org_id)
+            return
+
+        tk.get_action("member_request_create")(context, {
+            "object_id": org_id,
+            "object_type": "organization",
+            "type": "membership",
+            "message": "Auto-created from Auth0 role biocommons/group/tsi",
+        })
+        log.info("Created pending membership request for '%s' in '%s' via TSI role trigger", user_name, org_id)
+
+    except tk.ValidationError as e:
+        log.warning("Validation error creating membership request for '%s': %s", org_id, e)
+    except Exception as e:
+        log.error("Failed to create membership request for '%s' in '%s': %s", user_name, org_id, e)
+
+
+def apply_role_based_memberships(*, user_name: str, roles: List[str], context: Dict[str, Any]):
+    """
+    If user has 'biocommons/group/tsi', create a pending membership request
+    for the 'aai-threatened-species-initiative-embargo' org (idempotent).
+    """
+    if not roles:
+        return
+
+    if TSI_ROLE in set(roles):
+        # Ensure target org exists before attempting (avoid noise)
+        try:
+            tk.get_action("organization_show")(context, {"id": TSI_ORG_ID})
+        except tk.ObjectNotFound:
+            log.warning("Org '%s' not found in CKAN, skipping membership creation.", TSI_ORG_ID)
+            return
+
+        _create_pending_membership_if_absent(
+            org_id=TSI_ORG_ID,
+            user_name=user_name,
+            context=context,
+        )


### PR DESCRIPTION
### Summary

Implements [AAI-249 – Enable grant access to TSI embargo data](https://biocloud.atlassian.net/browse/AAI-249) by applying Auth0 role-based memberships at login. Users with the configured TSI role (`"biocommons/group/tsi"`) are automatically added to the corresponding CKAN organization (`"aai-threatened-species-initiative"`).

### Key Changes

- `get_oidc_user()`: now requires `access_token`, resolves/creates user, and applies memberships via Auth0 roles.

- Utilities: added `Auth0Settings`, `Auth0TokenService`, and `MembershipService` for role and membership handling.

- Blueprint: renamed to `oidc_pkce_bpa`; `/user/register` and `/user/login` routes updated.

- Tests: expanded coverage for new user creation, role-based memberships, error handling, and redirects.

### Related Pull Request
- All CKAN configs are added in https://github.com/BioplatformsAustralia/docker-bpa-ckan/pull/15/files (not yet to be merged)

See screenshot - the "AAI - Threatened Species Initiative" is the newly added organization to house all approved TSI bundled members.

<img width="1728" height="977" alt="Screenshot 2025-09-24 at 9 57 11 AM" src="https://github.com/user-attachments/assets/609c7d71-81f5-409b-a06b-84f7bf2bcf38" />
