### PR TITLE
Notify users when logging in with an unverified email

### DIFF
--- a/ckanext/oidc_pkce_bpa/tests/test_plugin.py
+++ b/ckanext/oidc_pkce_bpa/tests/test_plugin.py
@@ -16,8 +16,10 @@ from ckanext.oidc_pkce import views as oidc_views
 
 def register_oidc_blueprint(app):
     """Register the core OIDC blueprint and re-apply BPA overrides for each test app."""
+    oidc_views.bp._got_registered_once = False
     app.register_blueprint(oidc_views.bp)
-    plugin_module._register_callback_override(SimpleNamespace(app=app))
+    with app.app_context():
+        plugin_module._register_callback_override(SimpleNamespace(app=app))
 
 
 @pytest.fixture

--- a/ckanext/oidc_pkce_bpa/tests/test_plugin.py
+++ b/ckanext/oidc_pkce_bpa/tests/test_plugin.py
@@ -14,6 +14,12 @@ import ckanext.oidc_pkce_bpa.plugin as plugin_module
 from ckanext.oidc_pkce import views as oidc_views
 
 
+def register_oidc_blueprint(app):
+    """Register the core OIDC blueprint and re-apply BPA overrides for each test app."""
+    app.register_blueprint(oidc_views.bp)
+    plugin_module._register_callback_override(SimpleNamespace(app=app))
+
+
 @pytest.fixture
 def plugin():
     """Initialise the plugin once per test."""
@@ -262,7 +268,7 @@ def test_callback_access_denied_redirects_home(monkeypatch):
 
     app = Flask(__name__)
     app.secret_key = "testing"
-    app.register_blueprint(oidc_views.bp)
+    register_oidc_blueprint(app)
 
     client = app.test_client()
 
@@ -305,7 +311,7 @@ def test_force_login_triggers_prompt_when_flagged(monkeypatch):
 
     app = Flask(__name__)
     app.secret_key = "testing"
-    app.register_blueprint(oidc_views.bp)
+    register_oidc_blueprint(app)
 
     client = app.test_client()
 
@@ -334,7 +340,7 @@ def test_login_route_always_redirects_to_oidc(monkeypatch):
 
     app = Flask(__name__)
     app.secret_key = "testing"
-    app.register_blueprint(oidc_views.bp)
+    register_oidc_blueprint(app)
 
     client = app.test_client()
 


### PR DESCRIPTION
## Description
This PR updates the OIDC login flow to detect and handle unverified email addresses, ensuring users are notified and redirected back to CKAN instead of retrying Auth0.

##Changes

- Added `_oidc_callback_with_email_check` to intercept `access_denied` errors from Auth0.

- Display clear error message to users when signing in with an unverified email

- Override OIDC login and force login routes to respect new flow.

- Added `SESSION_FORCE_PROMPT` flag to trigger explicit Auth0 login prompt after denial.

- Implemented `oidc_login_response` to redirect failed login attempts back to CKAN home.

### Enhanced test suite:

- Tests for email verification denial handling.

- Tests for login response redirects and session cleanup.

- Tests for forced login prompt and legacy flags.

- Utility function register_oidc_blueprint added for test setup.
